### PR TITLE
Let's Use `const`

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ module.exports = {
     ],
     'no-constant-condition': 'off',
     'no-var': 'error',
+    'no-use-before-define': 'error',
     'quotes': ['error', 'single', { 'avoidEscape': true }],
     'semi': ['error', 'always'],
     'space-before-blocks': 'error',

--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ module.exports = {
     'no-constant-condition': 'off',
     'no-var': 'error',
     'no-use-before-define': 'error',
+    'prefer-const': 'error',
     'quotes': ['error', 'single', { 'avoidEscape': true }],
     'semi': ['error', 'always'],
     'space-before-blocks': 'error',

--- a/package.json
+++ b/package.json
@@ -8,5 +8,9 @@
   "license": "MIT",
   "peerDependencies": {
     "eslint": ">= 3"
-  }
+  },
+  "keywords": [
+    "lint",
+    "style guide"
+  ]
 }


### PR DESCRIPTION
`const` provides clear communication that a variable should not be reassigned, whereas `let` does. This is not only enforced by modern JS Engines, but we can even sniff out problems with ESLint. Let's use these tools to write more communicative code.